### PR TITLE
refactor!: remove `setSpeechRate` and `setPitchRate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,6 @@ const setSpeechRate = async () => {
 * [`getSupportedLanguages()`](#getsupportedlanguages)
 * [`getSupportedVoices()`](#getsupportedvoices)
 * [`openInstall()`](#openinstall)
-* [`setPitchRate(...)`](#setpitchrate)
-* [`setSpeechRate(...)`](#setspeechrate)
 * [Interfaces](#interfaces)
 
 </docgen-index>
@@ -190,40 +188,6 @@ openInstall() => Promise<void>
 ```
 
 Verifies proper installation and availability of resource files on the system.
-
---------------------
-
-
-### setPitchRate(...)
-
-```typescript
-setPitchRate(options: { pitchRate: number; }) => Promise<void>
-```
-
-Changes the pitch rate while the text is being played.
-
-Only available for Android.
-
-| Param         | Type                                |
-| ------------- | ----------------------------------- |
-| **`options`** | <code>{ pitchRate: number; }</code> |
-
---------------------
-
-
-### setSpeechRate(...)
-
-```typescript
-setSpeechRate(options: { speechRate: number; }) => Promise<void>
-```
-
-Changes the speech rate while the text is being played.
-
-Only available for Android.
-
-| Param         | Type                                 |
-| ------------- | ------------------------------------ |
-| **`options`** | <code>{ speechRate: number; }</code> |
 
 --------------------
 

--- a/android/src/main/java/com/getcapacitor/community/tts/TextToSpeech.java
+++ b/android/src/main/java/com/getcapacitor/community/tts/TextToSpeech.java
@@ -113,18 +113,6 @@ public class TextToSpeech implements android.speech.tts.TextToSpeech.OnInitListe
         return result;
     }
 
-    public void setPitch(float pitch) {
-        tts.setPitch(pitch);
-    }
-
-    public void setRate(float rate) {
-        if (Build.VERSION.SDK_INT >= 27) {
-            tts.setSpeechRate(rate * 0.7f);
-        } else {
-            tts.setSpeechRate(rate);
-        }
-    }
-
     public void openInstall() {
         PackageManager packageManager = context.getPackageManager();
         Intent installIntent = new Intent();

--- a/android/src/main/java/com/getcapacitor/community/tts/TextToSpeechPlugin.java
+++ b/android/src/main/java/com/getcapacitor/community/tts/TextToSpeechPlugin.java
@@ -101,28 +101,6 @@ public class TextToSpeechPlugin extends Plugin {
     }
 
     @PluginMethod
-    public void setPitchRate(final PluginCall call) {
-        float pitch = call.getFloat("pitchRate", 1.0f);
-        try {
-            implementation.setPitch(pitch);
-            call.resolve();
-        } catch (Exception ex) {
-            call.reject(ex.getLocalizedMessage());
-        }
-    }
-
-    @PluginMethod
-    public void setSpeechRate(final PluginCall call) {
-        float rate = call.getFloat("speechRate", 1.0f);
-        try {
-            implementation.setPitch(rate);
-            call.resolve();
-        } catch (Exception ex) {
-            call.reject(ex.getLocalizedMessage());
-        }
-    }
-
-    @PluginMethod
     public void openInstall(PluginCall call) {
         try {
             implementation.openInstall();

--- a/ios/Plugin/TextToSpeech.swift
+++ b/ios/Plugin/TextToSpeech.swift
@@ -42,14 +42,6 @@ import AVFoundation
         synthesizer.stopSpeaking(at: .immediate)
     }
 
-    @objc public func setSpeechRate(_ rate: Float) {
-        self.utterance?.rate = rate
-    }
-
-    @objc public func setPitchRate(_ pitch: Float) {
-        self.utterance?.pitchMultiplier = pitch
-    }
-
     @objc public func getSupportedLanguages() -> [String] {
         return Array(AVSpeechSynthesisVoice.speechVoices().map {
             return $0.language

--- a/ios/Plugin/TextToSpeechPlugin.m
+++ b/ios/Plugin/TextToSpeechPlugin.m
@@ -6,8 +6,6 @@
 CAP_PLUGIN(TextToSpeechPlugin, "TextToSpeech",
            CAP_PLUGIN_METHOD(speak, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(stop, CAPPluginReturnPromise);
-           CAP_PLUGIN_METHOD(setSpeechRate, CAPPluginReturnPromise);
-           CAP_PLUGIN_METHOD(setPitchRate, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(openInstall, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(getSupportedLanguages, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(getSupportedVoices, CAPPluginReturnPromise);

--- a/ios/Plugin/TextToSpeechPlugin.swift
+++ b/ios/Plugin/TextToSpeechPlugin.swift
@@ -42,24 +42,6 @@ public class TextToSpeechPlugin: CAPPlugin {
         call.resolve()
     }
 
-    @objc public func setSpeechRate(_ call: CAPPluginCall) {
-        guard let rate = call.getFloat("speechRate") else {
-            call.reject("speechRate must be provided and must be a number.")
-            return
-        }
-        implementation.setSpeechRate(rate)
-        call.resolve()
-    }
-
-    @objc public func setPitchRate(_ call: CAPPluginCall) {
-        guard let pitch = call.getFloat("pitchRate") else {
-            call.reject("pitchRate must be provided and must be a number.")
-            return
-        }
-        implementation.setPitchRate(pitch)
-        call.resolve()
-    }
-
     @objc func getSupportedLanguages(_ call: CAPPluginCall) {
         let languages = self.implementation.getSupportedLanguages()
         call.resolve([

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -19,18 +19,6 @@ export interface TextToSpeechPlugin {
    * Verifies proper installation and availability of resource files on the system.
    */
   openInstall(): Promise<void>;
-  /**
-   * Changes the pitch rate while the text is being played.
-   *
-   * Only available for Android.
-   */
-  setPitchRate(options: { pitchRate: number }): Promise<void>;
-  /**
-   * Changes the speech rate while the text is being played.
-   *
-   * Only available for Android.
-   */
-  setSpeechRate(options: { speechRate: number }): Promise<void>;
 }
 
 export interface TTSOptions {

--- a/src/web.ts
+++ b/src/web.ts
@@ -56,14 +56,6 @@ export class TextToSpeechWeb extends WebPlugin implements TextToSpeechPlugin {
     this.throwUnimplementedError();
   }
 
-  public async setPitchRate(_options: { pitchRate: number }): Promise<void> {
-    this.throwUnimplementedError();
-  }
-
-  public async setSpeechRate(_options: { speechRate: number }): Promise<void> {
-    this.throwUnimplementedError();
-  }
-
   private createSpeechSynthesisUtterance(
     options: TTSOptions,
   ): SpeechSynthesisUtterance {


### PR DESCRIPTION
`setSpeechRate` and `setPitchRate` are only available on Android. However, they do not work correctly on Android. For this reason, the support is removed for now.

