### PR TITLE
feat(android): support the `voice` property

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Only available for Android.
 | **`rate`**     | <code>number</code> | The speed at which the utterance will be spoken at. Default: `1.0`.                                                                                                                                |
 | **`pitch`**    | <code>number</code> | The pitch at which the utterance will be spoken at. Default: `1.0`.                                                                                                                                |
 | **`volume`**   | <code>number</code> | The volume that the utterance will be spoken at. Default: `1.0`.                                                                                                                                   |
-| **`voice`**    | <code>number</code> | The index of the selected voice that will be used to speak the utterance. Possible voices can be queried using `getSupportedVoices`. Only available for Web.                                       |
+| **`voice`**    | <code>number</code> | The index of the selected voice that will be used to speak the utterance. Possible voices can be queried using `getSupportedVoices`.                                                               |
 | **`category`** | <code>string</code> | Select the iOS Audio session category. Possible values: `ambient` and `playback`. Use `playback` to play audio even when the app is in the background. Only available for iOS. Default: `ambient`. |
 
 

--- a/android/src/main/java/com/getcapacitor/community/tts/TextToSpeech.java
+++ b/android/src/main/java/com/getcapacitor/community/tts/TextToSpeech.java
@@ -153,7 +153,7 @@ public class TextToSpeech implements android.speech.tts.TextToSpeech.OnInitListe
         Locale locale = voice.getLocale();
         JSObject obj = new JSObject();
         obj.put("voiceURI", voice.getName());
-        obj.put("name", locale.getDisplayLanguage() + " " + locale.getDisplayCountry());
+        obj.put("name", locale.getDisplayLanguage() + " " + locale.getDisplayCountry() + " " + voice.getName());
         obj.put("lang", locale.toLanguageTag());
         obj.put("localService", !voice.isNetworkConnectionRequired());
         obj.put("default", false);

--- a/android/src/main/java/com/getcapacitor/community/tts/TextToSpeech.java
+++ b/android/src/main/java/com/getcapacitor/community/tts/TextToSpeech.java
@@ -17,8 +17,6 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.Comparator;
 
-import android.util.Log;
-
 public class TextToSpeech implements android.speech.tts.TextToSpeech.OnInitListener {
 
     public static final String LOG_TAG = "TextToSpeech";
@@ -83,10 +81,6 @@ public class TextToSpeech implements android.speech.tts.TextToSpeech.OnInitListe
             ttsParams.putSerializable(android.speech.tts.TextToSpeech.Engine.KEY_PARAM_UTTERANCE_ID, callbackId);
             ttsParams.putSerializable(android.speech.tts.TextToSpeech.Engine.KEY_PARAM_VOLUME, volume);
 
-      Log.d("TTSS", "Voice Value " + String.valueOf(voice));
-
-
-
             tts.setLanguage(locale);
             tts.setSpeechRate(rate);
             tts.setPitch(pitch);
@@ -95,10 +89,7 @@ public class TextToSpeech implements android.speech.tts.TextToSpeech.OnInitListe
                 ArrayList<Voice> supportedVoices = getSupportedVoicesOrdered();
                 if (voice < supportedVoices.size()) {
                     Voice newVoice = supportedVoices.get(voice);
-                    Log.d("TTSS", "SETTING VOICE");
-                    Log.d("TTSS", newVoice.getName());
                     int resultCode = tts.setVoice(newVoice);
-                    Log.d("TTSS", String.valueOf(resultCode));
                 }
             }
 

--- a/android/src/main/java/com/getcapacitor/community/tts/TextToSpeech.java
+++ b/android/src/main/java/com/getcapacitor/community/tts/TextToSpeech.java
@@ -85,20 +85,24 @@ public class TextToSpeech implements android.speech.tts.TextToSpeech.OnInitListe
 
       Log.d("TTSS", "Voice Value " + String.valueOf(voice));
 
+
+
+            tts.setLanguage(locale);
+            tts.setSpeechRate(rate);
+            tts.setPitch(pitch);
+
             if (voice >= 0) {
                 ArrayList<Voice> supportedVoices = getSupportedVoicesOrdered();
                 if (voice < supportedVoices.size()) {
                     Voice newVoice = supportedVoices.get(voice);
-                          Log.d("TTSS", "SETTING VOICE");
+                    Log.d("TTSS", "SETTING VOICE");
                     Log.d("TTSS", newVoice.getName());
                     int resultCode = tts.setVoice(newVoice);
                     Log.d("TTSS", String.valueOf(resultCode));
                 }
             }
 
-            tts.setLanguage(locale);
-            tts.setSpeechRate(rate);
-            tts.setPitch(pitch);
+            
             tts.speak(text, android.speech.tts.TextToSpeech.QUEUE_FLUSH, ttsParams, callbackId);
         } else {
             HashMap<String, String> ttsParams = new HashMap<>();

--- a/android/src/main/java/com/getcapacitor/community/tts/TextToSpeech.java
+++ b/android/src/main/java/com/getcapacitor/community/tts/TextToSpeech.java
@@ -181,7 +181,7 @@ public class TextToSpeech implements android.speech.tts.TextToSpeech.OnInitListe
         Locale locale = voice.getLocale();
         JSObject obj = new JSObject();
         obj.put("voiceURI", voice.getName());
-        obj.put("name", locale.getDisplayLanguage() + " " + locale.getDisplayCountry() + " " + voice.getName());
+        obj.put("name", locale.getDisplayLanguage() + " " + locale.getDisplayCountry());
         obj.put("lang", locale.toLanguageTag());
         obj.put("localService", !voice.isNetworkConnectionRequired());
         obj.put("default", false);

--- a/android/src/main/java/com/getcapacitor/community/tts/TextToSpeech.java
+++ b/android/src/main/java/com/getcapacitor/community/tts/TextToSpeech.java
@@ -12,10 +12,10 @@ import android.util.Log;
 import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Set;
-import java.util.Comparator;
 
 public class TextToSpeech implements android.speech.tts.TextToSpeech.OnInitListener {
 
@@ -39,9 +39,6 @@ public class TextToSpeech implements android.speech.tts.TextToSpeech.OnInitListe
     public void onInit(int status) {
         this.initializationStatus = status;
     }
-
-
-
 
     public void speak(
         String text,
@@ -90,7 +87,6 @@ public class TextToSpeech implements android.speech.tts.TextToSpeech.OnInitListe
                 }
             }
 
-            
             tts.speak(text, android.speech.tts.TextToSpeech.QUEUE_FLUSH, ttsParams, callbackId);
         } else {
             HashMap<String, String> ttsParams = new HashMap<>();

--- a/android/src/main/java/com/getcapacitor/community/tts/TextToSpeech.java
+++ b/android/src/main/java/com/getcapacitor/community/tts/TextToSpeech.java
@@ -43,9 +43,6 @@ public class TextToSpeech implements android.speech.tts.TextToSpeech.OnInitListe
 
 
 
-    //A brief note on the voice property:
-    //voice is an index for the voice, and should probably be replaced by a string in the future (or perhaps with a voiceURI option in-lieu of voice)
-    //As is, we need to assign indices to the set in order to match things. 
     public void speak(
         String text,
         String lang,

--- a/android/src/main/java/com/getcapacitor/community/tts/TextToSpeechPlugin.java
+++ b/android/src/main/java/com/getcapacitor/community/tts/TextToSpeechPlugin.java
@@ -35,6 +35,8 @@ public class TextToSpeechPlugin extends Plugin {
         float rate = call.getFloat("rate", 1.0f);
         float pitch = call.getFloat("pitch", 1.0f);
         float volume = call.getFloat("volume", 1.0f);
+        float tempVoice = call.getFloat("voice", -1.0f);
+        int voice = (int) tempVoice;
 
         boolean isLanguageSupported = implementation.isLanguageSupported(lang);
         if (!isLanguageSupported) {
@@ -55,7 +57,7 @@ public class TextToSpeechPlugin extends Plugin {
         };
 
         try {
-            implementation.speak(text, lang, rate, pitch, volume, call.getCallbackId(), resultCallback);
+            implementation.speak(text, lang, rate, pitch, volume, voice, call.getCallbackId(), resultCallback);
         } catch (Exception ex) {
             call.reject(ex.getLocalizedMessage());
         }

--- a/android/src/main/java/com/getcapacitor/community/tts/TextToSpeechPlugin.java
+++ b/android/src/main/java/com/getcapacitor/community/tts/TextToSpeechPlugin.java
@@ -35,8 +35,7 @@ public class TextToSpeechPlugin extends Plugin {
         float rate = call.getFloat("rate", 1.0f);
         float pitch = call.getFloat("pitch", 1.0f);
         float volume = call.getFloat("volume", 1.0f);
-        float tempVoice = call.getFloat("voice", -1.0f);
-        int voice = (int) tempVoice;
+        int voice = call.getInt("voice", -1);
 
         boolean isLanguageSupported = implementation.isLanguageSupported(lang);
         if (!isLanguageSupported) {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -62,8 +62,6 @@ export interface TTSOptions {
   /**
    * The index of the selected voice that will be used to speak the utterance.
    * Possible voices can be queried using `getSupportedVoices`.
-   *
-   * Only available for Web.
    */
   voice?: number;
   /**


### PR DESCRIPTION
This finishes the second part of #38 (so once PR #89 and this are merged, #38 can be closed). 
Both of these PRs should be fully backwards compatible (I did change the generation of names a little in this one to make them all unique, which can be undone easily without adverse consequences)

Ultimately, it needs to be considered if the current voice property needs to be replaced with a voiceURI in the future for simplicity. That said, these PRs use the voice property identically to the current web behavior, and there's no immediate reason for any sort of breaking change (especially since I've already written the code for the current API)