### PR TITLE
feat(ios): support the `voice` property

### DIFF
--- a/ios/Plugin/TextToSpeech.swift
+++ b/ios/Plugin/TextToSpeech.swift
@@ -18,7 +18,7 @@ import Capacitor
         self.resolveCurrentCall()
     }
 
-    @objc public func speak(_ text: String, _ lang: String, _ rate: Float, _ pitch: Float, _ category: String, _ volume: Float, _ call: CAPPluginCall) throws {
+    @objc public func speak(_ text: String, _ lang: String, _ rate: Float, _ pitch: Float, _ category: String, _ volume: Float, _ voice : Int, _ call: CAPPluginCall) throws {
         self.synthesizer.stopSpeaking(at: .immediate)
 
         var avAudioSessionCategory = AVAudioSession.Category.ambient
@@ -36,6 +36,16 @@ import Capacitor
         utterance.rate = adjustRate(rate)
         utterance.pitchMultiplier = pitch
         utterance.volume = volume
+
+        //Find the voice associated with the voice parameter if a voice specified. 
+        //If the specified voice is not available we will fall back to default voice rather than raising an error. 
+        if (voice >= 0) {
+            let allVoices = AVSpeechSynthesisVoice.speechVoices()
+            if (voice < allVoices.count) {
+                utterance.voice = allVoices[voice]
+            }
+        }
+
         synthesizer.speak(utterance)
     }
 

--- a/ios/Plugin/TextToSpeechPlugin.swift
+++ b/ios/Plugin/TextToSpeechPlugin.swift
@@ -17,6 +17,7 @@ public class TextToSpeechPlugin: CAPPlugin {
         let rate = call.getFloat("rate") ?? 1.0
         let pitch = call.getFloat("pitch") ?? 1.0
         let volume = call.getFloat("volume") ?? 1.0
+        let voice = call.getInt("voice") ?? -1
         let category = call.getString("category") ?? "ambient"
 
         let isLanguageSupported = implementation.isLanguageSupported(lang)
@@ -26,7 +27,7 @@ public class TextToSpeechPlugin: CAPPlugin {
         }
 
         do {
-            try implementation.speak(text, lang, rate, pitch, category, volume, call)
+            try implementation.speak(text, lang, rate, pitch, category, volume, voice, call)
         } catch {
             call.reject(error.localizedDescription)
         }


### PR DESCRIPTION
Implement voice property on iOS. Note that without getSupportedVoices (#91), there's not a good way to select a specific voice so this property is mostly useless. 