### PR TITLE
Ensure Android voice names are unique

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/tts/TextToSpeech.java
+++ b/android/src/main/java/com/getcapacitor/community/tts/TextToSpeech.java
@@ -153,7 +153,7 @@ public class TextToSpeech implements android.speech.tts.TextToSpeech.OnInitListe
         Locale locale = voice.getLocale();
         JSObject obj = new JSObject();
         obj.put("voiceURI", voice.getName());
-        obj.put("name", locale.getDisplayLanguage() + " " + locale.getDisplayCountry());
+        obj.put("name", locale.getDisplayLanguage() + " " + locale.getDisplayCountry() + " " + voice.getName());
         obj.put("lang", locale.toLanguageTag());
         obj.put("localService", !voice.isNetworkConnectionRequired());
         obj.put("default", false);


### PR DESCRIPTION
Expand the name property - this ensures that Android voice packages should have distinctly different names when shown to users. (close #95)

Don't love this formatting, so interested in alternative ideas as for ensuring voice names are unique but user friendly. 