### PR TITLE
Fix support issue on API levels < 24

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/tts/TextToSpeech.java
+++ b/android/src/main/java/com/getcapacitor/community/tts/TextToSpeech.java
@@ -115,6 +115,9 @@ public class TextToSpeech implements android.speech.tts.TextToSpeech.OnInitListe
         return result;
     }
 
+    /**
+     * @return Ordered list of voices. The order is guaranteed to remain the same as long as the voices in tts.getVoices() do not change.
+     */
     public ArrayList<Voice> getSupportedVoicesOrdered() {
         Set<Voice> supportedVoices = tts.getVoices();
         ArrayList<Voice> orderedVoices = new ArrayList<Voice>();
@@ -122,7 +125,8 @@ public class TextToSpeech implements android.speech.tts.TextToSpeech.OnInitListe
             orderedVoices.add(supportedVoice);
         }
 
-        Collections.sort(orderedVoices, (v1, v2) -> v1.hashCode() - v2.hashCode());
+        //voice.getName() is guaranteed to be unique, so will be used for sorting.
+        Collections.sort(orderedVoices, (v1, v2) -> v1.getName().compareTo(v2.getName()));
 
         return orderedVoices;
     }

--- a/android/src/main/java/com/getcapacitor/community/tts/TextToSpeech.java
+++ b/android/src/main/java/com/getcapacitor/community/tts/TextToSpeech.java
@@ -13,7 +13,6 @@ import com.getcapacitor.JSArray;
 import com.getcapacitor.JSObject;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Set;
@@ -123,7 +122,7 @@ public class TextToSpeech implements android.speech.tts.TextToSpeech.OnInitListe
             orderedVoices.add(supportedVoice);
         }
 
-        Collections.sort(orderedVoices, Comparator.comparing(Voice::hashCode));
+        Collections.sort(orderedVoices, (v1, v2) -> v1.hashCode() - v2.hashCode());
 
         return orderedVoices;
     }


### PR DESCRIPTION
Comparator.comparing does not work below API level 24. This PR switches to use a lambda expression instead. 

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The changes have been tested successfully.
