### PR TITLE
fix(ios)!: linear rate adjustment

### DIFF
--- a/ios/Plugin/TextToSpeech.swift
+++ b/ios/Plugin/TextToSpeech.swift
@@ -68,14 +68,11 @@ import Capacitor
 
     // Adjust rate for a closer match to other platform.
     @objc private func adjustRate(_ rate: Float) -> Float {
-        let baseRate = AVSpeechUtteranceDefaultSpeechRate
-        if rate == 1 {
-            return baseRate
-        }
-        if rate > baseRate {
-            return baseRate + (rate * 0.025)
-        }
-        return rate / 2
+         let baseRate: Float = AVSpeechUtteranceDefaultSpeechRate
+         if (rate >= 1.0 ) {
+             return (0.1 * rate) + (baseRate - 0.1)
+         }
+        return rate * baseRate
     }
 
     @objc private func resolveCurrentCall() {


### PR DESCRIPTION
Closes: https://github.com/capacitor-community/text-to-speech/issues/134

Changes iOS rate mapping from
![rateAdjustment-before](https://github.com/user-attachments/assets/d06550a8-b5fd-4f15-8814-cae0fc10bd26)
to a more predictable mapping
![rateAdjustment-after](https://github.com/user-attachments/assets/065d5daf-a86f-4711-8ba5-3d08644e394b)
(x-axis = plugin speech rate, y-axis = native speech rate, assuming `AVSpeechUtteranceDefaultSpeechRate` is 0.5)

Note: Speech rate heavily depends on the selected tts-engine and voice. There will not be a perfect cross-platform speech rate match. From experimenting with android and iOS tts-engines and voices this adjustment seems to be a good compromise.
We should also consider removing the rate adjustment completely though. See a similar discussion on `react-native-tts` [here](https://github.com/ak1394/react-native-tts/issues/10). But that is another discussion.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [X] The changes have been tested successfully.


