### PR TITLE
chore(ci): Run build on Xcode 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
     name: Build
     runs-on: macos-15
     steps:
+      - run: sudo xcode-select --switch /Applications/Xcode_16.app
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up Node.js ${{ env.NODE_VERSION }}


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] The changes have been tested successfully.

macos-15 is switching to Xcode 16.4 and it has no simulators installed, so build fails
changing Xcode version to 16.0 to fix the issue and also because it's recommended to test on that version since Capacitor supports 16.0+ and sometimes new code is introduced that doesn't build in older versions, so better test on the min supported version.
