### PR TITLE
feat(ios): support `onRangeStart` listener

### DIFF
--- a/ios/Sources/TextToSpeechPlugin/TextToSpeechPlugin.swift
+++ b/ios/Sources/TextToSpeechPlugin/TextToSpeechPlugin.swift
@@ -20,7 +20,11 @@ public class TextToSpeechPlugin: CAPPlugin, CAPBridgedPlugin {
     ]
     private static let errorUnsupportedLanguage = "This language is not supported."
 
-    private let implementation = TextToSpeech()
+    private var implementation: TextToSpeech!
+
+    public override func load() {
+        implementation = TextToSpeech(plugin: self)
+    }
 
     @objc public func speak(_ call: CAPPluginCall) {
         let text = call.getString("text") ?? ""


### PR DESCRIPTION
This reopens https://github.com/capacitor-community/text-to-speech/pull/144

It provides support for addRangeListener on iOS. So far, it was available only for Android, as exposed here: https://github.com/capacitor-community/text-to-speech/issues/140 and https://github.com/capacitor-community/text-to-speech/pull/132

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The changes have been tested successfully.
