### PR TITLE
fix(ios)!: create a separate audio session to automatically manage speech

### DIFF
--- a/ios/Sources/TextToSpeechPlugin/TextToSpeech.swift
+++ b/ios/Sources/TextToSpeechPlugin/TextToSpeech.swift
@@ -12,17 +12,8 @@ enum QUEUE_STRATEGY: Int {
 
     override init() {
         super.init()
+        self.synthesizer.usesApplicationAudioSession = false
         self.synthesizer.delegate = self
-        // set session in background to avoid UI hangs.
-        queue.async {
-            do {
-                let avAudioSessionCategory: AVAudioSession.Category = .playback
-                try AVAudioSession.sharedInstance().setCategory(avAudioSessionCategory, mode: .default, options: .duckOthers)
-                try AVAudioSession.sharedInstance().setActive(true)
-            } catch {
-                print("Error setting up AVAudioSession: \(error)")
-            }
-        }
     }
 
     public func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didCancel utterance: AVSpeechUtterance) {


### PR DESCRIPTION
Completely removing the plugin’s custom `avSession` setting in favor of `usesApplicationAudioSession = false`.

https://developer.apple.com/documentation/avfaudio/avspeechsynthesizer/usesapplicationaudiosession

> If you set this value to [false](https://developer.apple.com/documentation/Swift/false), **the system creates a separate audio session to automatically manage speech, interruptions, and mixing and ducking the speech with other audio sources**.

- Fixes #138 introduced in #135
- Fixes unintended ducking on app start (also mentioned in an [issue comment](https://github.com/capacitor-community/text-to-speech/issues/138#issuecomment-2433471207) )

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] The changes have been tested successfully.
  - [x] Tested on iOS 18.5
  - [x] Tested on iOS 14.8
