### PR TITLE
fix: Use two-parameter API for Capacitor 8 Swift compatibility

### DIFF
--- a/ios/Sources/TextToSpeechPlugin/TextToSpeechPlugin.swift
+++ b/ios/Sources/TextToSpeechPlugin/TextToSpeechPlugin.swift
@@ -23,14 +23,14 @@ public class TextToSpeechPlugin: CAPPlugin, CAPBridgedPlugin {
     private let implementation = TextToSpeech()
 
     @objc public func speak(_ call: CAPPluginCall) {
-        let text = call.getString("text") ?? ""
-        let lang = call.getString("lang") ?? "en-US"
-        let rate = call.getFloat("rate") ?? 1.0
-        let pitch = call.getFloat("pitch") ?? 1.0
-        let volume = call.getFloat("volume") ?? 1.0
-        let voice = call.getInt("voice") ?? -1
-        let category = call.getString("category") ?? "ambient"
-        let queueStrategy = call.getInt("queueStrategy") ?? 0
+        let text = call.getString("text", "")
+        let lang = call.getString("lang", "en-US")
+        let rate = call.getFloat("rate", 1.0)
+        let pitch = call.getFloat("pitch", 1.0)
+        let volume = call.getFloat("volume", 1.0)
+        let voice = call.getInt("voice", -1)
+        let category = call.getString("category", "ambient")
+        let queueStrategy = call.getInt("queueStrategy", 0)
 
         let isLanguageSupported = implementation.isLanguageSupported(lang)
         guard isLanguageSupported else {
@@ -82,7 +82,7 @@ public class TextToSpeechPlugin: CAPPlugin, CAPBridgedPlugin {
     }
 
     @objc func isLanguageSupported(_ call: CAPPluginCall) {
-        let lang = call.getString("lang") ?? ""
+        let lang = call.getString("lang", "")
         let isLanguageSupported = self.implementation.isLanguageSupported(lang)
         call.resolve([
             "supported": isLanguageSupported


### PR DESCRIPTION
## Problem

The v8.0.0 release uses the single-parameter `getString`/`getFloat`/`getInt` API with nil-coalescing:

```swift
let text = call.getString("text") ?? ""
```

However, when building with Capacitor 8 and Swift Package Manager, this causes compilation errors:

```
error: missing argument for parameter #2 in call
    let text = call.getString("text") ?? ""
                                    ^
```

The Capacitor 8 xcframework only exposes the two-parameter variant of these methods.

## Solution

Update all parameter extraction calls to use the two-parameter style:

```swift
let text = call.getString("text", "")
```

This is the same style used by official Capacitor 8 plugins (e.g., `@capacitor/status-bar`).

## Changes

- `speak()`: Updated 8 parameter extractions
- `isLanguageSupported()`: Updated 1 parameter extraction

## Testing

Built and tested against Capacitor 8.0.0 with Swift Package Manager.